### PR TITLE
Extend the `add` method to handle new lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An example Java project, including Gradle, JUnit, and Azure Pipelines, to demons
 
 [![Build Status](https://dev.azure.com/sfratt/string-calculator/_apis/build/status/sfratt.string-calculator?branchName=master)](https://dev.azure.com/sfratt/string-calculator/_build/latest?definitionId=4&branchName=master)
 
-The project contains a simple Java application that performs arithmetic on string inputs, and provides a test suite with [JUnit 4](https://junit.org/junit4/).  The `build.gradle` file provides configuration that can automate builds using a continuous integration tool like [Azure DevOps](https://azure.com/devops).
+The project contains a simple Java application that performs arithmetic on string inputs, and provides a test suite with [JUnit 4](https://junit.org/junit4/). [Gradle](https://gradle.org/) provides configuration that can automate builds using a continuous integration tool like [Azure DevOps](https://azure.com/devops).
 
 To initialize and build a Gradle project, simply:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@
 
 trigger:
 - master
+- releases/*
 
 strategy:
   matrix:

--- a/src/main/java/string/calculator/StringCalculator.java
+++ b/src/main/java/string/calculator/StringCalculator.java
@@ -4,11 +4,11 @@ public class StringCalculator {
 
     public static final int add(final String numbers) {
         int returnValue = 0;
-        String[] numbersArray = numbers.split(",");
+        String[] numbersArray = numbers.split(",|\n");
 
         for (String number : numbersArray) {
             if (!number.trim().isEmpty()) {
-                returnValue += Integer.parseInt(number);
+                returnValue += Integer.parseInt(number.trim());
             }
         }
 

--- a/src/test/java/string/calculator/StringCalculatorTest.java
+++ b/src/test/java/string/calculator/StringCalculatorTest.java
@@ -34,4 +34,9 @@ public class StringCalculatorTest {
     public final void whenAnyNumberOfNumbersIsUsedThenReturnValuesAreTheirSums() {
         Assert.assertEquals(3+6+15+18+46+33, StringCalculator.add("3,6,15,18,46,33"));
     }
+
+    @Test
+    public final void whenNewLineIsUsedBetweenNumbersThenReturnValuesAreTheirSums() {
+        Assert.assertEquals(3+6+15, StringCalculator.add("3, 6\n15"));
+    }
 }


### PR DESCRIPTION

Add `|\n` to the split regex for new lines between numbers instead of
handling just commas.